### PR TITLE
Feature: Reducer and ObservableState macros. Removed ViewStore

### DIFF
--- a/templates/TCA Feature.xctemplate/___FILEBASENAME___+State.swift
+++ b/templates/TCA Feature.xctemplate/___FILEBASENAME___+State.swift
@@ -3,6 +3,7 @@
 import ComposableArchitecture
 
 extension ___VARIABLE_productName:identifier___ {
+  @ObservableState
   public struct State: Equatable {
     public init() {
     }

--- a/templates/TCA Feature.xctemplate/___FILEBASENAME___.swift
+++ b/templates/TCA Feature.xctemplate/___FILEBASENAME___.swift
@@ -2,7 +2,8 @@
 
 import ComposableArchitecture
 
-public struct ___VARIABLE_productName:identifier___: Reducer {
+@Reducer
+public struct ___VARIABLE_productName:identifier___ {
 
   public init() {}
 

--- a/templates/TCA Feature.xctemplate/___FILEBASENAME___View.swift
+++ b/templates/TCA Feature.xctemplate/___FILEBASENAME___View.swift
@@ -7,12 +7,9 @@ import ComposableArchitecture
 // MARK: - View
 
 public struct ___FILEBASENAMEASIDENTIFIER___: View {
-  @ObservedObject
-  private var viewStore: ViewStoreOf<___VARIABLE_productName:identifier___>
   private let store: StoreOf<___VARIABLE_productName:identifier___>
 
   public init(store: StoreOf<___VARIABLE_productName:identifier___>) {
-    self.viewStore = .init(store, observe: { $0 })
     self.store = store
   }
 
@@ -21,7 +18,7 @@ public struct ___FILEBASENAMEASIDENTIFIER___: View {
       Text("Hello, ___VARIABLE_productName:identifier___!")
     }
     .task {
-      await viewStore
+      await store
         .send(.onAppear)
         .finish()
     }
@@ -40,3 +37,4 @@ public struct ___FILEBASENAMEASIDENTIFIER___: View {
     )
   )
 }
+


### PR DESCRIPTION
Cause in new TCA we dont use ViewStore anymore and we have macros, I've added feature template to able to use 

**ObservableState**
**Reducer**

and removed ViewStore from view.

I've tested and it generates correctly, builds and works.